### PR TITLE
Feat/parallel indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mydata.idx
 gmi
+/testdocs

--- a/testdocs/doc1.txt
+++ b/testdocs/doc1.txt
@@ -1,1 +1,0 @@
-Hello world this is a test.

--- a/testdocs/doc2.md
+++ b/testdocs/doc2.md
@@ -1,2 +1,0 @@
-Another test document for GoMyIndex.
-Hello again


### PR DESCRIPTION
This pull request refactors the `BuildIndex` function in `indexer/indexer.go` to improve performance and scalability by introducing concurrent file processing. It also removes two test documents (`doc1.txt` and `doc2.md`) from the `testdocs` directory.

### Refactoring of `BuildIndex` function:

* Introduced worker goroutines for concurrent file processing, leveraging the number of CPU cores (`runtime.NumCPU`) to determine the number of workers. This change improves the efficiency of indexing large numbers of files.
* Added a `processdFileResult` struct and channels (`jobs` and `results`) to manage communication between workers and the main thread. This ensures structured handling of file processing results and errors.
* Enhanced error handling during file scanning and processing, including logging errors and skipping problematic files without halting the entire indexing process.
* Improved progress reporting by displaying updates every 100 files processed, providing better visibility into the indexing progress.

### Test document removals:

* Removed `testdocs/doc1.txt`, which contained a simple test message.
* Removed `testdocs/doc2.md`, which contained a multi-line test message.