### PR TITLE
Feat/multi words

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"gmi/searcher"
 	"gmi/store"
 	"os"
+	"strings"
 )
 
 func main() {
@@ -101,15 +102,18 @@ func handleSearchCommand() {
 		return
 	}
 
-	fmt.Printf("Found %d document(s):\n", len(searchResults))
+	fmt.Printf("Found %d document(s) matching all terms:\n", len(searchResults))
 	for i, res := range searchResults {
 		fmt.Printf("%d. File: %s (DocID: %d)\n", i+1, res.Document.Path, res.Document.ID)
-		if len(res.Positions) > 0 {
-			displayPositions := res.Positions
-			if len(displayPositions) > 5 {
-				displayPositions = displayPositions[:5]
+
+		var termDetails []string
+		for term, positions := range res.QueryTermPositions {
+			displayPositions := positions
+			if len(displayPositions) > 3 {
+				displayPositions = displayPositions[:3]
 			}
-			fmt.Printf("   Query term positions in document: %v\n", displayPositions)
+			termDetails = append(termDetails, fmt.Sprintf("'%s' at %v", term, displayPositions))
 		}
+		fmt.Printf("   Terms found: %s\n", strings.Join(termDetails, "; "))
 	}
 }

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -9,50 +9,88 @@ import (
 
 // SearchResult は検索結果の1つのアイテムを表します。
 type SearchResult struct {
-	Document  indexer.Document
-	Positions []int // クエリ単語の出現位置
+	Document           indexer.Document
+	QueryTermPositions map[string][]int // key: 検索クエリのトークン, value: そのトークンの出現位置リスト
 }
 
-// Search は指定されたインデックス内でクエリに一致するドキュメントを検索します。
-// 現状は単一キーワード検索のみをサポートします。
+// Searchは指定されたインデックス内でクエリに一致するドキュメントを検索します
 func Search(idx *indexer.InvertedIndex, query string) []SearchResult {
-	var results []SearchResult
+	var finalResults []SearchResult
 
 	if idx == nil || idx.Index == nil || idx.Docs == nil {
 		fmt.Println("Error: Index is not properly initialized.")
-		return results
+		return finalResults
 	}
 
 	queryTokens := tokenizer.Tokenize(query)
 	if len(queryTokens) == 0 {
 		fmt.Println("Warning: Empty query after tokenization.")
-		return results
+		return finalResults
 	}
 
-	searchTerm := queryTokens[0]
-	fmt.Printf("Searching for term: '%s'\n", searchTerm)
+	fmt.Printf("Searching for terms (AND): %v\n", queryTokens)
 
-	postings, found := idx.Index[searchTerm]
-	if !found {
-		fmt.Printf("Term '%s' not found in index.\n", searchTerm)
-		return results
-	}
+	postingLists := make(map[string][]indexer.Posting)
+	shortestPostingListLength := -1
+	var shortestToken string
 
-	for _, posting := range postings {
-		doc, docExists := idx.Docs[posting.DocID]
-		if docExists {
-			results = append(results, SearchResult{
-				Document:  doc,
-				Positions: posting.Positions,
-			})
-		} else {
-			fmt.Printf("Warning: DocID %d found in posting for term '%s', but not in Docs map.\n", posting.DocID, searchTerm)
+	for _, token := range queryTokens {
+		postings, found := idx.Index[token]
+		if !found {
+			fmt.Printf("Term '%s' not found in index. No results for AND search.\n", token)
+			return finalResults
+		}
+		postingLists[token] = postings
+		if shortestPostingListLength == -1 || len(postings) < shortestPostingListLength {
+			shortestPostingListLength = len(postings)
+			shortestToken = token
 		}
 	}
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Document.ID < results[j].Document.ID
+	if shortestToken == "" {
+		return finalResults
+	}
+
+	candidateDocs := make(map[int]map[string][]int) // DocID -> {token -> positions}
+
+	for _, p := range postingLists[shortestToken] {
+		candidateDocs[p.DocID] = map[string][]int{
+			shortestToken: p.Positions,
+		}
+	}
+
+	for token, postings := range postingLists {
+		if token == shortestToken {
+			continue
+		}
+
+		currentMatchingDocs := make(map[int]map[string][]int)
+		for _, p := range postings {
+			if existingMatchData, ok := candidateDocs[p.DocID]; ok {
+				existingMatchData[token] = p.Positions
+				currentMatchingDocs[p.DocID] = existingMatchData
+			}
+		}
+		candidateDocs = currentMatchingDocs
+		if len(candidateDocs) == 0 {
+			fmt.Println("No documents match all query terms.")
+			return finalResults
+		}
+	}
+
+	for docID, termPositionsMap := range candidateDocs {
+		doc, docExists := idx.Docs[docID]
+		if docExists {
+			finalResults = append(finalResults, SearchResult{
+				Document:           doc,
+				QueryTermPositions: termPositionsMap,
+			})
+		}
+	}
+
+	sort.Slice(finalResults, func(i, j int) bool {
+		return finalResults[i].Document.ID < finalResults[j].Document.ID
 	})
 
-	return results
+	return finalResults
 }


### PR DESCRIPTION
This pull request enhances the search functionality by implementing multi-term AND searches and improving the output format for search results. Key changes include updating the data structure for query term positions, modifying the search algorithm to handle multiple terms, and improving the display of search results.

### Enhancements to search functionality:

* **Multi-term AND search support**: Updated the `Search` function in `searcher/searcher.go` to support multi-term AND searches. It now processes multiple query tokens, identifies candidate documents containing all terms, and tracks the positions of each term in the documents.
* **Optimized candidate document selection**: Introduced logic to prioritize the shortest posting list for efficient candidate document selection, reducing the computational overhead for multi-term searches.

### Improvements to search result output:

* **Detailed term positions in results**: Modified the `SearchResult` structure to include a map of query terms to their positions, replacing the single list of positions. Updated the output in `main.go` to display term-specific positions in a user-friendly format. [[1]](diffhunk://#diff-57b375a80cf4cd4695cd6af4b4ee0729ae20d085c29e195bb8384dcc57bd2b4cL13-R95) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L104-R117)

### Codebase adjustments:

* **Refactored imports**: Added the `strings` package to `main.go` to support string manipulation for formatting search results.